### PR TITLE
判空处理

### DIFF
--- a/src/class11/Code03_EncodeNaryTreeToBinaryTree.java
+++ b/src/class11/Code03_EncodeNaryTreeToBinaryTree.java
@@ -58,7 +58,7 @@ public class Code03_EncodeNaryTreeToBinaryTree {
 					cur.right = tNode;
 				}
 				cur = tNode;
-				cur.left = en(child.children);
+				cur.left = child.children != null ? en(child.children) : null;
 			}
 			return head;
 		}
@@ -72,7 +72,7 @@ public class Code03_EncodeNaryTreeToBinaryTree {
 		}
 
 		public List<Node> de(TreeNode root) {
-			List<Node> children = new ArrayList<>();
+			List<Node> children = root != null ? new ArrayList<>() : null;
 			while (root != null) {
 				Node cur = new Node(root.val, de(root.left));
 				children.add(cur);


### PR DESCRIPTION
由于题中的Node的构造器其中无参和有一个参数的构造器中，关于List<Node> children可能会存在空，所以当List为空时encode的递归方法会存在空指针的问题；同理decode的递归也会存在本来是null的children被赋值为非null的空ArrayList